### PR TITLE
Remove unused unsafe blocks, remove #![allow(unused_unsafe)]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -904,12 +904,10 @@ impl<'a> App<'a> {
     let id = self.alloc_id();
 
     let mob =
-      unsafe {
-        mob::Mob {
-          speed: Vec3::new(0.0, 0.0, 0.0),
-          behavior: behavior,
-          id: id,
-        }
+      mob::Mob {
+        speed: Vec3::new(0.0, 0.0, 0.0),
+        behavior: behavior,
+        id: id,
       };
 
     let bounds = AABB::new(low_corner, low_corner + Vec3::new(1.0, 2.0, 1.0 as GLfloat));
@@ -920,7 +918,7 @@ impl<'a> App<'a> {
   }
 
   fn place_block(&mut self, min: Vec3<GLfloat>, max: Vec3<GLfloat>, block_type: block::BlockType, check_collisions: bool) {
-    time!(&self.timers, "place_block", || unsafe {
+    time!(&self.timers, "place_block", || {
       let mut block = block::Block {
         block_type: block_type,
         id: Id(0),
@@ -1139,9 +1137,7 @@ pub fn main() {
 
   gl.print_stats();
 
-  unsafe {
-    App::new(gl).run(&mut window);
-  }
+  App::new(gl).run(&mut window);
 
   println!("finished!");
   println!("");

--- a/src/playform.rs
+++ b/src/playform.rs
@@ -7,10 +7,6 @@
 #![feature(unsafe_destructor)]
 #![feature(phase)]
 
-// TODO(cgaebel): This is just to make the `time` macro work. I'm not sure how
-// to disable warnings only in a macro.
-#![allow(unused_unsafe)]
-
 extern crate gl;
 extern crate glw;
 extern crate input;


### PR DESCRIPTION
I just started looking at the code so I might be missing something. I didn't experience the problem described by the todo this removes, but this seems to work just fine... perhaps the language changed in the mean time.
