### PR TITLE
Update to the last ncollide API.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@ use gl::types::*;
 use glw::color::Color4;
 use glw::vertex::{ColoredVertex};
 use nalgebra::Pnt3;
-use ncollide::bounding_volume::aabb::AABB;
+use ncollide::bounding_volume::AABB3;
 
 pub const WINDOW_WIDTH:  uint = 800;
 pub const WINDOW_HEIGHT: uint = 600;
@@ -47,7 +47,7 @@ pub fn partial_min_by<A: Copy, T: Iterator<A>, B: PartialOrd>(t: T, f: |A| -> B)
   min_a
 }
 
-pub fn to_outlines<'a>(bounds: &AABB) -> [ColoredVertex, ..LINE_VERTICES_PER_BOX] {
+pub fn to_outlines<'a>(bounds: &AABB3) -> [ColoredVertex, ..LINE_VERTICES_PER_BOX] {
   let (x1, y1, z1) = (bounds.mins().x, bounds.mins().y, bounds.mins().z);
   let (x2, y2, z2) = (bounds.maxs().x, bounds.maxs().y, bounds.maxs().z);
   let c = Color4::of_rgba(0.0, 0.0, 0.0, 0.1);
@@ -77,7 +77,7 @@ pub fn to_outlines<'a>(bounds: &AABB) -> [ColoredVertex, ..LINE_VERTICES_PER_BOX
   ]
 }
 
-pub fn to_triangles(bounds: &AABB, c: &Color4<GLfloat>) -> [ColoredVertex, ..VERTICES_PER_TRIANGLE * TRIANGLES_PER_BOX] {
+pub fn to_triangles(bounds: &AABB3, c: &Color4<GLfloat>) -> [ColoredVertex, ..VERTICES_PER_TRIANGLE * TRIANGLES_PER_BOX] {
   let (x1, y1, z1) = (bounds.mins().x, bounds.mins().y, bounds.mins().z);
   let (x2, y2, z2) = (bounds.maxs().x, bounds.maxs().y, bounds.maxs().z);
 

--- a/src/glw/camera.rs
+++ b/src/glw/camera.rs
@@ -1,5 +1,6 @@
 use gl::types::*;
-use nalgebra::{Mat3, Mat4, Vec3, Pnt3, Eye, Outer};
+use nalgebra::{Mat3, Mat4, Vec3, Pnt3};
+use nalgebra;
 
 pub struct Camera {
   // projection matrix components
@@ -23,7 +24,7 @@ pub fn from_axis_angle3(axis: Vec3<GLfloat>, angle: GLfloat) -> Mat3<GLfloat> {
   let (s, c) = angle.sin_cos();
   let Vec3 { x: xs, y: ys, z: zs } = axis * s;
   let vsub1c = axis * (1.0 - c);
-  Outer::outer(&vsub1c, &vsub1c) +
+  nalgebra::outer(&vsub1c, &vsub1c) +
     Mat3 {
       m11: c,   m12: -zs, m13: ys,
       m21: zs,  m22: c,   m23: -xs,
@@ -82,9 +83,9 @@ impl Camera {
   /// and [0, -1] in z in depth.
   pub fn unit() -> Camera {
     Camera {
-      translation: Eye::new_identity(4),
-      rotation: Eye::new_identity(4),
-      fov: Eye::new_identity(4),
+      translation: nalgebra::new_identity(4),
+      rotation: nalgebra::new_identity(4),
+      fov: nalgebra::new_identity(4),
       position: Pnt3::new(0.0, 0.0, 0.0),
     }
   }

--- a/src/glw/gl_buffer.rs
+++ b/src/glw/gl_buffer.rs
@@ -50,8 +50,8 @@ impl GLByteBuffer {
 
     match gl::GetError() {
       gl::NO_ERROR => {},
-      gl::OUT_OF_MEMORY => fail!("Out of VRAM"),
-      err => fail!("OpenGL error 0x{:x}", err),
+      gl::OUT_OF_MEMORY => panic!("Out of VRAM"),
+      err => panic!("OpenGL error 0x{:x}", err),
     }
 
     GLByteBuffer {
@@ -82,7 +82,7 @@ impl GLByteBuffer {
 
       match gl::GetError() {
         gl::NO_ERROR => {},
-        err => fail!("OpenGL error 0x{:x} in update", err),
+        err => panic!("OpenGL error 0x{:x} in update", err),
       }
 
     // In the `i == self.length` case, we don't bother with the swap;
@@ -98,7 +98,7 @@ impl GLByteBuffer {
 
       match gl::GetError() {
         gl::NO_ERROR => {},
-        err => fail!("OpenGL error 0x{:x} in update", err),
+        err => panic!("OpenGL error 0x{:x} in update", err),
       }
 
       gl::CopyBufferSubData(
@@ -111,7 +111,7 @@ impl GLByteBuffer {
 
       match gl::GetError() {
         gl::NO_ERROR => {},
-        err => fail!("OpenGL error 0x{:x} in update", err),
+        err => panic!("OpenGL error 0x{:x} in update", err),
       }
     }
   }
@@ -126,7 +126,7 @@ impl GLByteBuffer {
 
     match gl::GetError() {
       gl::NO_ERROR => {},
-      err => fail!("OpenGL error 0x{:x} in GLByteBuffer::update", err),
+      err => panic!("OpenGL error 0x{:x} in GLByteBuffer::update", err),
     }
 
     gl::BindBuffer(gl::ARRAY_BUFFER, self.gl_id);
@@ -142,7 +142,7 @@ impl GLByteBuffer {
 
     match gl::GetError() {
       gl::NO_ERROR => {},
-      err => fail!("OpenGL error 0x{:x} in GLByteBuffer::update_inner", err),
+      err => panic!("OpenGL error 0x{:x} in GLByteBuffer::update_inner", err),
     }
   }
 }
@@ -287,7 +287,7 @@ impl<T> GLArray<T> {
 
     match gl::GetError() {
       gl::NO_ERROR => {},
-      err => fail!("OpenGL error 0x{:x}", err),
+      err => panic!("OpenGL error 0x{:x}", err),
     }
 
     assert!(mem::size_of::<T>() % attrib_span == 0);
@@ -328,7 +328,7 @@ impl<T> GLArray<T> {
 
     match gl::GetError() {
       gl::NO_ERROR => {},
-      err => fail!("OpenGL error 0x{:x}", err),
+      err => panic!("OpenGL error 0x{:x}", err),
     }
   }
 }

--- a/src/glw/gl_context.rs
+++ b/src/glw/gl_context.rs
@@ -106,7 +106,7 @@ impl GLContext {
         gl::GetShaderiv(shader, gl::INFO_LOG_LENGTH, &mut len);
         let mut buf = Vec::from_elem(len as uint - 1, 0u8); // subtract 1 to skip the trailing null character
         gl::GetShaderInfoLog(shader, len, ptr::null_mut(), buf.as_mut_ptr() as *mut GLchar);
-        fail!("error compiling 0x{:x} shader: {}", ty, str::from_utf8(buf.as_slice()).expect("ShaderInfoLog not valid utf8"));
+        panic!("error compiling 0x{:x} shader: {}", ty, str::from_utf8(buf.as_slice()).expect("ShaderInfoLog not valid utf8"));
       }
     }
     shader

--- a/src/glw/shader.rs
+++ b/src/glw/shader.rs
@@ -48,7 +48,7 @@ impl Shader {
         unsafe {
           gl::GetProgramInfoLog(program, len, ptr::null_mut(), buf.as_mut_ptr() as *mut GLchar);
         }
-        fail!("{}", str::from_utf8(buf.as_slice()).expect("ProgramInfoLog not valid utf8"));
+        panic!("{}", str::from_utf8(buf.as_slice()).expect("ProgramInfoLog not valid utf8"));
     }
 
     Shader {
@@ -74,7 +74,7 @@ impl Shader {
 
           match gl::GetError() {
             gl::NO_ERROR => {},
-            err => fail!("OpenGL error 0x{:x} in GetUniformLocation", err),
+            err => panic!("OpenGL error 0x{:x} in GetUniformLocation", err),
           }
 
           (loc, f(loc))
@@ -88,7 +88,7 @@ impl Shader {
 
     match gl::GetError() {
       gl::NO_ERROR => {},
-      err => fail!("OpenGL error 0x{:x} in with_uniform_location callback", err),
+      err => panic!("OpenGL error 0x{:x} in with_uniform_location callback", err),
     }
 
     t
@@ -120,7 +120,7 @@ impl Shader {
 
       match gl::GetError() {
         gl::NO_ERROR => {},
-        err => fail!("OpenGL error 0x{:x} in UniformMat4fv", err),
+        err => panic!("OpenGL error 0x{:x} in UniformMat4fv", err),
       }
     })
   }

--- a/src/glw/texture.rs
+++ b/src/glw/texture.rs
@@ -46,7 +46,7 @@ impl Texture {
 
     match gl::GetError() {
       gl::NO_ERROR => {},
-      err => fail!("OpenGL error 0x{:x}", err),
+      err => panic!("OpenGL error 0x{:x}", err),
     }
   }
 
@@ -56,7 +56,7 @@ impl Texture {
 
     match gl::GetError() {
       gl::NO_ERROR => {},
-      err => fail!("OpenGL error 0x{:x}", err),
+      err => panic!("OpenGL error 0x{:x}", err),
     }
   }
 }

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,17 +1,16 @@
 use nalgebra::Vec3;
-use ncollide::bounding_volume::aabb::AABB;
-use ncollide::math::Scalar;
+use ncollide::bounding_volume::{AABB, AABB3};
 use octree::Octree;
 use std::collections::HashMap;
 use std::hash::Hash;
 
 pub struct Physics<T> {
   pub octree: Octree<T>,
-  pub bounds: HashMap<T, AABB>,
+  pub bounds: HashMap<T, AABB3>,
 }
 
 impl<T: Copy + Eq + PartialOrd + Hash> Physics<T> {
-  pub fn insert(&mut self, t: T, bounds: &AABB) {
+  pub fn insert(&mut self, t: T, bounds: &AABB3) {
     self.octree.insert(bounds.clone(), t);
     self.bounds.insert(t, bounds.clone());
   }
@@ -25,11 +24,11 @@ impl<T: Copy + Eq + PartialOrd + Hash> Physics<T> {
     }
   }
 
-  pub fn get_bounds(&self, t: T) -> Option<&AABB> {
+  pub fn get_bounds(&self, t: T) -> Option<&AABB3> {
     self.bounds.find(&t)
   }
 
-  pub fn reinsert(octree: &mut Octree<T>, t: T, bounds: &mut AABB, new_bounds: AABB) -> Option<(AABB, T)> {
+  pub fn reinsert(octree: &mut Octree<T>, t: T, bounds: &mut AABB3, new_bounds: AABB3) -> Option<(AABB3, T)> {
     match octree.intersect(&new_bounds, Some(t)) {
       None => {
         octree.reinsert(t, bounds, new_bounds);
@@ -40,7 +39,7 @@ impl<T: Copy + Eq + PartialOrd + Hash> Physics<T> {
     }
   }
 
-  pub fn translate(&mut self, t: T, amount: Vec3<Scalar>) -> Option<(AABB, T)> {
+  pub fn translate(&mut self, t: T, amount: Vec3<f32>) -> Option<(AABB3, T)> {
     let bounds = self.bounds.find_mut(&t).unwrap();
     let new_bounds =
       AABB::new(

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,9 +1,8 @@
 use gl::types::*;
 use glw::camera;
 use nalgebra::Vec3;
-use nalgebra::RMul;
 use ncollide::bounding_volume::AABB;
-use ncollide::ray::Ray;
+use ncollide::ray::{Ray, Ray3};
 use physics::Physics;
 use state::EntityId;
 use std::f32::consts::PI;
@@ -109,8 +108,7 @@ impl Player {
 
     let y_axis = Vec3::new(0.0, 1.0, 0.0);
     let walk_v =
-        camera::from_axis_angle3(y_axis, self.lateral_rotation)
-        .rmul(&self.walk_accel);
+        camera::from_axis_angle3(y_axis, self.lateral_rotation) * self.walk_accel;
     self.speed = self.speed + walk_v + self.accel;
     // friction
     self.speed = self.speed * Vec3::new(0.7, 0.99, 0.7 as f32);
@@ -149,8 +147,8 @@ impl Player {
   /// Return the "right" axis (i.e. the x-axis rotated to match you).
   pub fn right(&self) -> Vec3<GLfloat> {
     return
-      camera::from_axis_angle3(Vec3::new(0.0, 1.0, 0.0), self.lateral_rotation)
-        .rmul(&Vec3::new(1.0, 0.0, 0.0))
+      camera::from_axis_angle3(Vec3::new(0.0, 1.0, 0.0), self.lateral_rotation) *
+      Vec3::new(1.0, 0.0, 0.0)
   }
 
   /// Return the "Ray axis (i.e. the z-axis rotated to match you).
@@ -160,10 +158,11 @@ impl Player {
       camera::from_axis_angle3(self.right(), self.vertical_rotation) *
       camera::from_axis_angle3(y_axis, self.lateral_rotation);
     let forward_orig = Vec3::new(0.0, 0.0, -1.0);
-    return transform.rmul(&forward_orig);
+
+    transform * forward_orig
   }
 
-  pub fn forward_ray(&self) -> Ray {
-    Ray { orig: self.camera.position, dir: self.forward() }
+  pub fn forward_ray(&self) -> Ray3 {
+    Ray::new(self.camera.position, self.forward())
   }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -49,7 +49,7 @@ pub fn render<'a>(app: &mut App<'a>) {
 
     match gl::GetError() {
       gl::NO_ERROR => {},
-      err => fail!("OpenGL error 0x{:x}", err),
+      err => panic!("OpenGL error 0x{:x}", err),
     }
 
     // draw hud textures

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -156,17 +156,17 @@ pub fn from_files<T: Iterator<(String, GLenum)>>(
           Ok(s) => {
             match preprocess(s, vars) {
               None => {
-                fail!("Failed to preprocess shader \"{}\".", path);
+                panic!("Failed to preprocess shader \"{}\".", path);
               },
               Some(s) => (s, component_type),
             }
           },
           Err(e) => {
-            fail!("Couldn't read shader file \"{}\": {}", path, e);
+            panic!("Couldn't read shader file \"{}\": {}", path, e);
           }
         },
       Err(e) => {
-        fail!("Couldn't open shader file \"{}\" for reading: {}", path, e);
+        panic!("Couldn't open shader file \"{}\" for reading: {}", path, e);
       }
     }
   }))
@@ -185,7 +185,7 @@ pub fn from_file_prefix<T: Iterator<GLenum>>(
         gl::VERTEX_SHADER => "vert",
         gl::FRAGMENT_SHADER => "frag",
         gl::GEOMETRY_SHADER => "geom",
-        _ => fail!("Unknown shader component type: {}", component),
+        _ => panic!("Unknown shader component type: {}", component),
       };
       ((prefix + "." + suffix), component)
     }),

--- a/src/stopwatch.rs
+++ b/src/stopwatch.rs
@@ -81,7 +81,7 @@ impl TimerSet {
       self.timers.borrow().find_equiv(&name).unwrap().clone();
 
     match timer.try_borrow_mut() {
-      None => fail!("timer \"{}\" used recursively", name),
+      None => panic!("timer \"{}\" used recursively", name),
       Some(mut timer) => timer.timed(f),
     }
   }

--- a/src/update.rs
+++ b/src/update.rs
@@ -36,7 +36,7 @@ pub fn update<'a>(app: &mut App) {
 
       match gl::GetError() {
         gl::NO_ERROR => {},
-        err => fail!("OpenGL error 0x{:x} in update", err),
+        err => panic!("OpenGL error 0x{:x} in update", err),
       }
 
     time!(app.timers.deref(), "update.load", || {
@@ -44,7 +44,7 @@ pub fn update<'a>(app: &mut App) {
 
       match gl::GetError() {
         gl::NO_ERROR => {},
-        err => fail!("OpenGL error 0x{:x} in update", err),
+        err => panic!("OpenGL error 0x{:x} in update", err),
       }
       load_octree(app);
     });


### PR DESCRIPTION
Replace ncollide types/traits:
- AABB (except. ctors) -> AABB3 (type alias)
- Ray  (except. ctors) -> Ray3 (type alias)
- RayCast              -> LocalRayCast (new trait for transformationless ray casting)
- Scalar               -> f32 (Scalar is now a trait)

Replace ncollide odd patterns:
- Ray { ... } -> Ray::new(...)

Replace nalgebra odd patterns:
- Cross::cross         -> nalgebra::cross
- Norm::normalize_copy -> nalgebra::normalize
- Norm::norm           -> nalgebra::norm
- Eye::new_identity    -> nalgebra::new_identity
- matrix.rmul(vector)  -> matrix \* vector (operator everload!)
- point1.as_vec() - point2.as_vec().clone() -> point1 - point2 (operator overload for points: Point - Point = Vector)

Update to the last Rust:
- fail!(...)-> panic!(...)
