### PR TITLE
Setting features and allowing deprecation because of thread::scoped

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "yaglw"
 version = "0.0.0"
-source = "git+https://github.com/bfops/yaglw#e7335ebe1075d5a614392bb3369b80001858f316"
+source = "git+https://github.com/bfops/yaglw#544e7cf36a27d6fd6da32af671e6a0673bcdd105"
 dependencies = [
  "gl 0.0.12 (git+https://github.com/bjz/gl-rs)",
  "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/src/mod.rs
+++ b/client/src/mod.rs
@@ -2,13 +2,16 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(deprecated)]
 
-#![feature(core)]
 #![feature(duration)]
 #![feature(main)]
 #![feature(scoped)]
 #![feature(test)]
 #![feature(unboxed_closures)]
+#![feature(range_inclusive)]
+#![feature(cmp_partial)]
+#![feature(ptr_as_ref)]
 
 extern crate cgmath;
 extern crate common;

--- a/common/serialize/lib.rs
+++ b/common/serialize/lib.rs
@@ -4,9 +4,9 @@
 // TODO: Make this work with less common endiannesses too.
 
 #![deny(warnings)]
-#![feature(collections)]
 #![feature(convert)]
-#![feature(core)]
+#![feature(raw)]
+#![feature(vec_push_all)]
 
 #![cfg_attr(test, feature(test))] 
 

--- a/common/src/mod.rs
+++ b/common/src/mod.rs
@@ -3,10 +3,11 @@
 
 //! Data structures and functions shared between server and client.
 
-#![feature(core)]
 #![feature(duration)]
 #![feature(test)]
 #![feature(unboxed_closures)]
+#![feature(range_inclusive)]
+#![feature(iter_cmp)]
 
 extern crate cgmath;
 #[macro_use]

--- a/server/src/mod.rs
+++ b/server/src/mod.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(deprecated)]
 
 #![feature(duration)]
 #![feature(main)]

--- a/server/terrain/mod.rs
+++ b/server/terrain/mod.rs
@@ -1,4 +1,6 @@
-#![feature(core)]
+#![feature(range_inclusive)]
+#![feature(cmp_partial)]
+#![feature(iter_cmp)]
 
 extern crate cgmath;
 extern crate common;


### PR DESCRIPTION
Changing feature gates to allow compilation on the nightly.

Thread::scoped has been deprecated. So I set it to allow use of deprecated features. It should be refactored away, but I am not yet fluent enough in rust to do it on my own.