### PR TITLE
Make playform compile with rust nightly 28th Oct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some picture things:
 
 Make sure you have:
 
-  * The **2015-10-15 nightly build** of the Rust compiler and cargo. It's possible that other versions will work.
+  * The **2015-10-28 nightly build** of the Rust compiler and cargo. It's possible that other versions will work.
   * OpenGL 3.3+
   * libpng
   * SDL2

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -2,7 +2,7 @@
 
 use cgmath::Point3;
 use std::collections::HashMap;
-use std::iter::range_inclusive;
+use num::iter::range_inclusive;
 use std::sync::Mutex;
 
 use common::block_position::BlockPosition;

--- a/client/src/mod.rs
+++ b/client/src/mod.rs
@@ -8,7 +8,6 @@
 #![feature(plugin)]
 #![feature(test)]
 #![feature(unboxed_closures)]
-#![feature(range_inclusive)]
 #![feature(ptr_as_ref)]
 
 #![allow(mutex_atomic)]

--- a/common/cube_shell.rs
+++ b/common/cube_shell.rs
@@ -3,7 +3,7 @@
 use cgmath::{Point, Point3, Vector3};
 use range_abs::range_abs;
 use std::cmp::{min, max};
-use std::iter::range_inclusive;
+use num::iter::range_inclusive;
 
 #[cfg(test)]
 use std::collections::HashSet;

--- a/common/mod.rs
+++ b/common/mod.rs
@@ -7,7 +7,6 @@
 #![feature(core)]
 #![feature(iter_cmp)]
 #![feature(plugin)]
-#![feature(range_inclusive)]
 #![feature(test)]
 #![feature(unboxed_closures)]
 

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "isosurface-extraction 0.0.0 (git+https://github.com/bfops/rust-isosurface-extraction)",
  "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "noise 0.1.5 (git+https://github.com/bjz/noise-rs)",
+ "num 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "playform-common 0.0.0",
  "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "stopwatch 0.0.0 (git+https://github.com/bfops/stopwatch-rs)",

--- a/server/terrain/Cargo.toml
+++ b/server/terrain/Cargo.toml
@@ -13,6 +13,7 @@ clippy = "*"
 log = "*"
 rand = "*"
 time = "*"
+num = "*"
 
 [dependencies.playform-common]
 path = "../../common"

--- a/server/terrain/generate.rs
+++ b/server/terrain/generate.rs
@@ -1,9 +1,9 @@
 use cgmath::{Aabb3, Point3, Point, Vector3};
 use isosurface_extraction::dual_contouring;
-use std;
 use std::sync::Mutex;
 use stopwatch;
 use voxel_data;
+use num::iter::range_inclusive;
 
 use common::block_position::BlockPosition;
 use common::entity::EntityId;
@@ -179,9 +179,9 @@ pub fn generate_block<Mosaic>(
 
     {
       let mut edges = |direction, low_x, high_x, low_y, high_y, low_z, high_z| {
-        for x in std::iter::range_inclusive(low_x, high_x) {
-        for y in std::iter::range_inclusive(low_y, high_y) {
-        for z in std::iter::range_inclusive(low_z, high_z) {
+        for x in range_inclusive(low_x, high_x) {
+        for y in range_inclusive(low_y, high_y) {
+        for z in range_inclusive(low_z, high_z) {
           let edge = 
             dual_contouring::edge::T {
               low_corner: Point3::new(x, y, z),

--- a/server/terrain/mod.rs
+++ b/server/terrain/mod.rs
@@ -9,7 +9,6 @@
 
 #![feature(main)]
 #![feature(plugin)]
-#![feature(range_inclusive)]
 #![feature(test)]
 #![feature(unboxed_closures)]
 
@@ -26,6 +25,7 @@ extern crate stopwatch;
 extern crate test;
 extern crate time;
 extern crate voxel_data;
+extern crate num;
 
 mod generate;
 pub mod biome;
@@ -36,7 +36,7 @@ pub use noise::Seed;
 
 use cgmath::Aabb;
 use std::collections::hash_map::HashMap;
-use std::iter::range_inclusive;
+use num::iter::range_inclusive;
 use std::sync::Mutex;
 
 use common::block_position::BlockPosition;


### PR DESCRIPTION
```std::iter::range_inclusive``` has been deprecated in favor
of the coming ```...``` syntax, which is not yet implemented.
In the meantime, ```num::iter::range_inclusive``` can be used
as drop-in replacement.