### PR TITLE
Server build error: use of `unwrap_or` followed by a function call

### DIFF
--- a/server/bin/mod.rs
+++ b/server/bin/mod.rs
@@ -25,7 +25,7 @@ fn main() {
   let mut args = env::args();
   args.next().unwrap();
   let listen_url
-    = args.next().unwrap_or(String::from("ipc:///tmp/server.ipc"));
+    = args.next().unwrap_or_else(|| String::from("ipc:///tmp/server.ipc"));
   assert!(args.next().is_none());
 
   info!("Listening on {}.", listen_url);


### PR DESCRIPTION
Hi!

This is a great project!  I want to help, but am quite new to Rust, so I might not know what I'm doing...

I got this error when building the server:

    Compiling server v0.0.0 (file:///home/dylan/dev/pkg/playform-server/src/playform-master/server/bin)
    mod.rs:28:7: 28:67 error: use of `unwrap_or` followed by a function call, #[deny(or_fun_call)] on by default
    mod.rs:28     = args.next().unwrap_or(String::from("ipc:///tmp/server.ipc"));
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    mod.rs:28:7: 28:67 help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#or_fun_call
    mod.rs:28:7: 28:67 help: try this
    mod.rs:       = args.next().unwrap_or_else(|| String::from("ipc:///tmp/server.ipc"));
    error: aborting due to previous error
    Could not compile `server`.

After following the "unwrap_or_else" advice, I was able to build it, so here is that change as a PR.  

By the way, I added a package to the AUR so it's easier to install/update on Arch Linux.

https://aur.archlinux.org/packages/playform-server/

I think it might be better to make separate repositories for client/server, and "common" stuff could be in yet another eg. lib-playform.

Cheers