### PR TITLE
Add piston's fps_counter

### DIFF
--- a/client/lib/Cargo.toml
+++ b/client/lib/Cargo.toml
@@ -22,6 +22,7 @@ sdl2 = "0.9.*"
 sdl2-sys = "0.6.*"
 thread-scoped = "*"
 time = "*"
+fps_counter = "*"
 
 [dependencies.playform-common]
 path = "../../common"

--- a/client/lib/src/view.rs
+++ b/client/lib/src/view.rs
@@ -1,5 +1,7 @@
 //! The state associated with perceiving the world state.
 
+extern crate fps_counter;
+
 use cgmath;
 use cgmath::Vector2;
 use std;
@@ -44,6 +46,9 @@ pub struct T<'a> {
 
   #[allow(missing_docs)]
   pub show_hud: bool,
+  
+  /// A counter of frames per second
+  pub fps_counter: fps_counter::FPSCounter,
 }
 
 impl<'a> T<'a> {
@@ -129,6 +134,8 @@ impl<'a> T<'a> {
       },
 
       show_hud: true,
+      
+      fps_counter: fps_counter::FPSCounter::new(),
     }
   }
 }

--- a/client/lib/src/view_thread.rs
+++ b/client/lib/src/view_thread.rs
@@ -146,6 +146,12 @@ pub fn view_thread<Recv0, Recv1, UpdateServer>(
 
         let renders = render_timer.update(time::precise_time_ns());
         if renders > 0 {
+          
+          let fps = view.fps_counter.tick();
+          
+          // TODO: display in client
+          //println!("{}", fps);
+          
           stopwatch::time("render", || {
             render(&mut view);
             // swap buffers


### PR DESCRIPTION
I'm trying to learn Rust, figured I would start with something small...

https://github.com/bfops/playform/issues/37

This PR includes the fps_counter crate (from Piston developers), and displays the FPS (commented out in view_thread.rs).

Let me know if this looks good, and I'll add something to display it in the viewport, otherwise please let me know how it could be done better.