### PR TITLE
Clippy updated to 0.0.42 and new_ret_no_self allowed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "playform"
 path = "src/mod.rs"
 
 [dependencies]
-clippy = "0.0.41"
+clippy = "0.0.42"
 env_logger= "*"
 log = "*"
 nanomsg = "*"

--- a/client/lib/src/mod.rs
+++ b/client/lib/src/mod.rs
@@ -12,6 +12,7 @@
 #![allow(match_same_arms)]
 
 #![plugin(clippy)]
+#![allow(new_ret_no_self)]
 
 extern crate bincode;
 extern crate cgmath;


### PR DESCRIPTION
Some changes because playform couldn't be compiled with new rust nightly