### PR TITLE
Fixed some linting issues

### DIFF
--- a/client/lib/src/view/grass_buffers.rs
+++ b/client/lib/src/view/grass_buffers.rs
@@ -201,7 +201,7 @@ impl<'a> T<'a> {
   // Note: `id` must be present in the buffers.
   /// Remove some entity from VRAM.
   pub fn swap_remove(&mut self, gl: &mut GLContext, id: entity_id::T) {
-    let idx = *self.id_to_index.get(&id).unwrap();
+    let idx = (*self).id_to_index[&id];
     let swapped_id = self.index_to_id[self.index_to_id.len() - 1];
     self.index_to_id.swap_remove(idx);
     self.id_to_index.remove(&id);
@@ -228,7 +228,7 @@ impl<'a> T<'a> {
         None => return,
         Some(id) => id,
       };
-    let entry_idx = self.id_to_index.get(&grass_id).unwrap();
+    let entry_idx = self.id_to_index[grass_id];
     // update the underlying byte buffer directly and only touch the polygon
     // index field.
     self.per_tuft.byte_buffer.bind(gl);

--- a/client/lib/src/view/terrain_buffers.rs
+++ b/client/lib/src/view/terrain_buffers.rs
@@ -170,7 +170,7 @@ impl<'a> T<'a> {
     id: entity_id::T,
   ) -> Option<(entity_id::T, usize)>
   {
-    let idx = *self.id_to_index.get(&id).unwrap();
+    let idx = (*self).id_to_index[&id];
     let swapped_id = self.index_to_id[self.index_to_id.len() - 1];
     self.index_to_id.swap_remove(idx);
     self.id_to_index.remove(&id);

--- a/server/lib/src/lod.rs
+++ b/server/lib/src/lod.rs
@@ -95,7 +95,7 @@ impl Map {
             prev_lod = None;
           },
           Some(position) => {
-            let &mut (_, ref mut cur_lod) = block_load_state.owner_lods.get_mut(position).unwrap();
+            let &mut (_, ref mut cur_lod) = &mut block_load_state.owner_lods[position];
             prev_lod = Some(*cur_lod);
             if lod == *cur_lod {
               return (prev_lod, None);


### PR DESCRIPTION
When trying to compile with rust nightly, version 1.16, I got an error regarding accessing vectors and hashmaps with .get(index).unwrap(). I believe this is due to updates in rust-clippy. I changed the statements as the compiler asked, and was able to compile.