### PR TITLE
Make buildall.sh shebang portable

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 R=0;
 for file in $(find . -name 'Cargo.toml'); do


### PR DESCRIPTION
Makes it possible to build on platforms where bash executable isn't located at /bin/bash